### PR TITLE
Update: Tax System

### DIFF
--- a/system/controllers/settings.php
+++ b/system/controllers/settings.php
@@ -119,7 +119,7 @@ switch ($action) {
                     die();
                 }
             }
-            // save all settings
+            // Save all settings including tax system
             foreach ($_POST as $key => $value) {
                 $d = ORM::for_table('tbl_appconfig')->where('setting', $key)->find_one();
                 if ($d) {
@@ -131,6 +131,33 @@ switch ($action) {
                     $d->value = $value;
                     $d->save();
                 }
+            }
+
+            // Handle tax system separately
+            $enable_tax = isset($_POST['enable_tax']) ? $_POST['enable_tax'] : 'no';
+            $tax_rate = isset($_POST['tax_rate']) ? $_POST['tax_rate'] : '0.01'; // Default tax rate 1%
+
+            // Save or update tax system settings
+            $d_tax_enable = ORM::for_table('tbl_appconfig')->where('setting', 'enable_tax')->find_one();
+            if ($d_tax_enable) {
+                $d_tax_enable->value = $enable_tax;
+                $d_tax_enable->save();
+            } else {
+                $d_tax_enable = ORM::for_table('tbl_appconfig')->create();
+                $d_tax_enable->setting = 'enable_tax';
+                $d_tax_enable->value = $enable_tax;
+                $d_tax_enable->save();
+            }
+
+            $d_tax_rate = ORM::for_table('tbl_appconfig')->where('setting', 'tax_rate')->find_one();
+            if ($d_tax_rate) {
+                $d_tax_rate->value = $tax_rate;
+                $d_tax_rate->save();
+            } else {
+                $d_tax_rate = ORM::for_table('tbl_appconfig')->create();
+                $d_tax_rate->setting = 'tax_rate';
+                $d_tax_rate->value = $tax_rate;
+                $d_tax_rate->save();
             }
 
             //checkbox

--- a/ui/ui/app-settings.tpl
+++ b/ui/ui/app-settings.tpl
@@ -553,6 +553,69 @@
                         <p class="help-block col-md-4">{Lang::T('The method which OTP will be sent to user')}</p>
                     </div>
                 </div>
+
+                <div class="panel-heading">
+                    <div class="btn-group pull-right">
+                        <button class="btn btn-primary btn-xs" title="save" type="submit">
+                            <span class="glyphicon glyphicon-floppy-disk" aria-hidden="true"></span>
+                        </button>
+                    </div>
+                    {Lang::T('Tax System')}
+                </div>
+                <div class="panel-body">
+                    <div class="form-group">
+                        <label class="col-md-2 control-label">{Lang::T('Enable Tax System')}</label>
+                        <div class="col-md-6">
+                            <select name="enable_tax" id="enable_tax" class="form-control">
+                                <option value="no" {if $_c['enable_tax']=='no' }selected="selected" {/if}>
+                                    {Lang::T('No')}
+                                </option>
+                                <option value="yes" {if $_c['enable_tax']=='yes' }selected="selected" {/if}>
+                                    {Lang::T('Yes')}
+                                </option>
+                            </select>
+                        </div>
+                        <p class="help-block col-md-4">{Lang::T('Tax will be calculated in Internet Plan Price')}</p>
+                    </div>
+                    <div class="form-group">
+                        <label class="col-md-2 control-label">{Lang::T('Tax Rate')}</label>
+                        <div class="col-md-6">
+                            <select name="tax_rate" id="tax_rate" class="form-control">
+                                <option value="0.005" {if $_c['tax_rate']=='0.005' }selected="selected" {/if}>
+                                    {Lang::T('0.5%')}
+                                </option>
+                                <option value="0.01" {if $_c['tax_rate']=='0.01' }selected="selected" {/if}>
+                                    {Lang::T('1%')}
+                                </option>
+                                <option value="0.015" {if $_c['tax_rate']=='0.015' }selected="selected" {/if}>
+                                    {Lang::T('1.5%')}
+                                </option>
+                                <option value="0.02" {if $_c['tax_rate']=='0.02' }selected="selected" {/if}>
+                                    {Lang::T('2%')}
+                                </option>
+                                <option value="0.05" {if $_c['tax_rate']=='0.05' }selected="selected" {/if}>
+                                    {Lang::T('5%')}
+                                </option>
+                                <option value="0.1" {if $_c['tax_rate']=='0.1' }selected="selected" {/if}>
+                                    {Lang::T('10%')}
+                                </option>
+                                <!-- Custom tax rate option -->
+                                <option value="custom" {if $_c['tax_rate']=='custom' }selected="selected" {/if}>{Lang::T('Custom')}</option>
+                            </select>
+                        </div>
+                        <p class="help-block col-md-4">{Lang::T('Tax Rates in percentage')}</p>
+                    </div>
+                    <!-- Custom tax rate input field (initially hidden) -->
+                    <div class="form-group" id="customTaxRate" style="display: none;">
+                        <label class="col-md-2 control-label">{Lang::T('Custom Tax Rate')}</label>
+                        <div class="col-md-6">
+                            <input type="text" value="{$_c['custom_tax_rate']}" class="form-control" name="custom_tax_rate" id="custom_tax_rate"
+                                   placeholder="{Lang::T('Enter Custom Tax Rate')}">
+                        </div>
+                        <p class="help-block col-md-4">{Lang::T('Enter the custom tax rate (e.g., 3.75 for 3.75%)')}</p>
+                    </div>
+                </div>
+                
                 {* <div class="panel-heading" id="envato">
                     <div class="btn-group pull-right">
                         <button class="btn btn-primary btn-xs" title="save" type="submit"><span
@@ -634,5 +697,27 @@ add dst-host=*.{$_domain}</pre>
     function testTg() {
         window.location.href = '{$_url}settings/app&testTg=test';
     }
+</script>
+
+<script>
+    document.addEventListener("DOMContentLoaded", function() {
+        // Function to toggle visibility of custom tax rate input field
+        function toggleCustomTaxRate() {
+            var taxRateSelect = document.getElementById("tax_rate");
+            var customTaxRateInput = document.getElementById("customTaxRate");
+
+            if (taxRateSelect.value === "custom") {
+                customTaxRateInput.style.display = "block";
+            } else {
+                customTaxRateInput.style.display = "none";
+            }
+        }
+
+        // Call the function when the page loads
+        toggleCustomTaxRate();
+
+        // Call the function whenever the tax rate dropdown value changes
+        document.getElementById("tax_rate").addEventListener("change", toggleCustomTaxRate);
+    });
 </script>
 {include file="sections/footer.tpl"}

--- a/ui/ui/balance-add.tpl
+++ b/ui/ui/balance-add.tpl
@@ -32,6 +32,16 @@
                                 <input type="number" class="form-control" name="price" required>
                             </div>
                         </div>
+                        {if $_c['enable_tax'] == 'yes'}
+                        {if $_c['tax_rate'] == 'custom'}
+                        <p class="help-block col-md-4">{number_format($_c['custom_tax_rate'], 2)} % {Lang::T('Tax Rates
+                            will be added')}</p>
+                        {else}
+                        <p class="help-block col-md-4">{number_format($_c['tax_rate'] * 100, 2)} % {Lang::T('Tax Rates
+                            will be added')}</p>
+                        {/if}
+                        {/if}
+
                     </div>
 
                     <div class="form-group">

--- a/ui/ui/balance-edit.tpl
+++ b/ui/ui/balance-edit.tpl
@@ -32,6 +32,16 @@
                                         <input type="number" class="form-control" name="price" value="{$d['price']}" required>
                                     </div>
                                 </div>
+                                {if $_c['enable_tax'] == 'yes'}
+                                {if $_c['tax_rate'] == 'custom'}
+                                <p class="help-block col-md-4">{number_format($_c['custom_tax_rate'], 2)} % {Lang::T('Tax Rates
+                                    will be added')}</p>
+                                {else}
+                                <p class="help-block col-md-4">{number_format($_c['tax_rate'] * 100, 2)} % {Lang::T('Tax Rates
+                                    will be added')}</p>
+                                {/if}
+                                {/if}
+        
                             </div>
 
                             <div class="form-group">

--- a/ui/ui/customers.tpl
+++ b/ui/ui/customers.tpl
@@ -106,7 +106,9 @@
 
     $j(document).ready(function () {
         $j('#customerTable').DataTable({
-            "pagingType": "full_numbers"
+            "pagingType": "full_numbers",
+            "lengthMenu": [ [5, 10, 25, 50, 100, -1], [5, 10, 25, 50, 100, "All"] ],
+            "pageLength": 5
         });
     });
 </script>

--- a/ui/ui/hotspot-add.tpl
+++ b/ui/ui/hotspot-add.tpl
@@ -114,6 +114,16 @@
                                 <input type="number" class="form-control" name="price" required>
                             </div>
                         </div>
+                        {if $_c['enable_tax'] == 'yes'}
+                        {if $_c['tax_rate'] == 'custom'}
+                        <p class="help-block col-md-4">{number_format($_c['custom_tax_rate'], 2)} % {Lang::T('Tax Rates
+                            will be added')}</p>
+                        {else}
+                        <p class="help-block col-md-4">{number_format($_c['tax_rate'] * 100, 2)} % {Lang::T('Tax Rates
+                            will be added')}</p>
+                        {/if}
+                        {/if}
+
                     </div>
                     <div class="form-group">
                         <label class="col-md-2 control-label">{Lang::T('Shared Users')}</label>

--- a/ui/ui/hotspot-edit.tpl
+++ b/ui/ui/hotspot-edit.tpl
@@ -133,6 +133,16 @@
                                 <input type="number" class="form-control" name="price" value="{$d['price']}" required>
                             </div>
                         </div>
+                        {if $_c['enable_tax'] == 'yes'}
+                        {if $_c['tax_rate'] == 'custom'}
+                        <p class="help-block col-md-4">{number_format($_c['custom_tax_rate'], 2)} % {Lang::T('Tax Rates
+                            will be added')}</p>
+                        {else}
+                        <p class="help-block col-md-4">{number_format($_c['tax_rate'] * 100, 2)} % {Lang::T('Tax Rates
+                            will be added')}</p>
+                        {/if}
+                        {/if}
+
                     </div>
                     <div class="form-group">
                         <label class="col-md-2 control-label">{Lang::T('Shared Users')}</label>

--- a/ui/ui/pppoe-add.tpl
+++ b/ui/ui/pppoe-add.tpl
@@ -64,6 +64,15 @@
                                 <input type="number" class="form-control" name="price" required>
                             </div>
                         </div>
+                        {if $_c['enable_tax'] == 'yes'}
+                        {if $_c['tax_rate'] == 'custom'}
+                        <p class="help-block col-md-4">{number_format($_c['custom_tax_rate'], 2)} % {Lang::T('Tax Rates
+                            will be added')}</p>
+                        {else}
+                        <p class="help-block col-md-4">{number_format($_c['tax_rate'] * 100, 2)} % {Lang::T('Tax Rates
+                            will be added')}</p>
+                        {/if}
+                        {/if}
                     </div>
                     <div class="form-group">
                         <label class="col-md-2 control-label">{Lang::T('Plan Validity')}</label>

--- a/ui/ui/pppoe-edit.tpl
+++ b/ui/ui/pppoe-edit.tpl
@@ -68,6 +68,16 @@
                                 <input type="number" class="form-control" name="price" required value="{$d['price']}">
                             </div>
                         </div>
+                        {if $_c['enable_tax'] == 'yes'}
+                        {if $_c['tax_rate'] == 'custom'}
+                        <p class="help-block col-md-4">{number_format($_c['custom_tax_rate'], 2)} % {Lang::T('Tax Rates
+                            will be added')}</p>
+                        {else}
+                        <p class="help-block col-md-4">{number_format($_c['tax_rate'] * 100, 2)} % {Lang::T('Tax Rates
+                            will be added')}</p>
+                        {/if}
+                        {/if}
+
                     </div>
                     <div class="form-group">
                         <label class="col-md-2 control-label">{Lang::T('Plan Validity')}</label>


### PR DESCRIPTION
Tax System Feature Added

The Tax System feature allows you to apply taxes to the prices of Internet plans. This feature is useful for businesses that are required to collect taxes on their services. With the Tax System, you can define tax rates based on your local tax regulations.

Enable Tax System: Choose whether to enable or disable the Tax System. When enabled, taxes will be calculated and added to the prices of Internet plans.

Tax Rate: Select from predefined tax rates such as 0.5%, 1%, 1.5%, 2%, 5%, and 10%. These rates are commonly used and can be selected easily.

Custom Tax Rate: If you have a specific tax rate that is not listed, you can enter a custom tax rate. This allows flexibility in configuring the tax rate to match your local tax requirements.