### PR TITLE
feat: Add RouterOS 7.18+ compatibility

### DIFF
--- a/system/autoload/PEAR2/Net/RouterOS/Response.php
+++ b/system/autoload/PEAR2/Net/RouterOS/Response.php
@@ -246,14 +246,13 @@ class Response extends Message
      *
      * @see getType()
      */
-    protected function setType($type)
-    {
-        switch ($type) {
+        protected function setType($type){
+    switch ($type) {
         case self::TYPE_FINAL:
-        case self::TYPE_EMPTY:
         case self::TYPE_DATA:
         case self::TYPE_ERROR:
         case self::TYPE_FATAL:
+        case '!empty': // Added this line to handle RouterOS 7.18+ responses and support older versions
             $this->_type = $type;
             return $this;
         default:
@@ -263,8 +262,8 @@ class Response extends Message
                 null,
                 $type
             );
-        }
     }
+}
 
     /**
      * Gets the response type.


### PR DESCRIPTION
## What This PR Solves
- Handles `!empty` responses in RouterOS 7.18+
- Maintains backward compatibility with older RouterOS versions

## Testing
- Verified on RouterOS 7.18.2 and Older versions
- Confirmed user creation with time/data limits works as expected
