### PR TITLE
Implement account expiration validation

### DIFF
--- a/radius.php
+++ b/radius.php
@@ -387,6 +387,17 @@ function process_radiust_rest($tur, $code)
 
     $attrs = [];
     $timeexp = strtotime($tur['expiration'] . ' ' . $tur['time']);
+  // --- Kode pengecekan masa aktif ---
+    if ($timeexp < time()) {
+        show_radius_result([
+            "control:Auth-Type" => "Reject",
+            "reply:Reply-Message" => "Sorry, your account's active period has expired (" . $tur['expiration'] . ")"
+        ], 401);
+        exit;
+    }
+    // --- AKHIR KODE TAMBAHAN ---
+
+    
     $attrs['reply:Reply-Message'] = 'success';
     $attrs['Simultaneous-Use'] = $plan['shared_users'];
     $attrs['reply:Mikrotik-Wireless-Comment'] = $plan['name_plan'] . ' | ' . $tur['expiration'] . ' ' . $tur['time'];


### PR DESCRIPTION
Saat ini radius.php tetap memberikan status Accept meskipun user sudah expired (WISPr-Session-Terminate-Time sudah lewat). Perubahan ini menambahkan pengecekan agar sistem mengirimkan status Reject (401) jika masa aktif habis.r account activity.
