### PR TITLE
Use parameterized queries for search filters

### DIFF
--- a/system/controllers/autoload.php
+++ b/system/controllers/autoload.php
@@ -169,7 +169,8 @@ switch ($action) {
         if (empty($s)) {
             $c = ORM::for_table('tbl_customers')->limit(30)->find_many();
         } else {
-            $c = ORM::for_table('tbl_customers')->where_raw("(`username` LIKE '%$s%' OR `fullname` LIKE '%$s%' OR `phonenumber` LIKE '%$s%' OR `email` LIKE '%$s%')")->limit(30)->find_many();
+            $like = '%' . $s . '%';
+            $c = ORM::for_table('tbl_customers')->where_raw("(`username` LIKE ? OR `fullname` LIKE ? OR `phonenumber` LIKE ? OR `email` LIKE ?)", [$like, $like, $like, $like])->limit(30)->find_many();
         }
         header('Content-Type: application/json');
         foreach ($c as $cust) {

--- a/system/controllers/customers.php
+++ b/system/controllers/customers.php
@@ -842,9 +842,11 @@ switch ($action) {
         $append_url = "&order=" . urlencode($order) . "&filter=" . urlencode($filter) . "&orderby=" . urlencode($orderby);
 
         if ($search != '') {
+            $like = '%' . $search . '%';
             $query = ORM::for_table('tbl_customers')
-                ->whereRaw("username LIKE '%$search%' OR fullname LIKE '%$search%' OR address LIKE '%$search%' " .
-                    "OR phonenumber LIKE '%$search%' OR email LIKE '%$search%' AND status='$filter'");
+                ->whereRaw("username LIKE ? OR fullname LIKE ? OR address LIKE ? " .
+                    "OR phonenumber LIKE ? OR email LIKE ? AND status = ?",
+                    [$like, $like, $like, $like, $like, $filter]);
         } else {
             $query = ORM::for_table('tbl_customers');
             $query->where("status", $filter);

--- a/system/controllers/mail.php
+++ b/system/controllers/mail.php
@@ -48,7 +48,8 @@ switch ($action) {
         $query = ORM::for_table('tbl_customers_inbox')->where('customer_id', $user['id'])->order_by_desc('date_created');
         $query->limit($limit)->offset($offset);
         if(!empty($q)){
-            $query->whereRaw("(subject like '%$q%' or body like '%$q%')");
+            $like = '%' . $q . '%';
+            $query->whereRaw("(subject LIKE ? OR body LIKE ?)", [$like, $like]);
         }
         $mails = $query->find_array();
         $ui->assign('tipe', '');

--- a/system/controllers/maps.php
+++ b/system/controllers/maps.php
@@ -22,7 +22,8 @@ switch ($action) {
     case 'customer':
         if(!empty(_req('search'))){
             $search = _req('search');
-            $query = ORM::for_table('tbl_customers')->whereRaw("coordinates != '' AND fullname LIKE '%$search%' OR username LIKE '%$search%' OR email LIKE '%$search%' OR phonenumber LIKE '%$search%'")->order_by_desc('fullname');
+            $like = '%' . $search . '%';
+            $query = ORM::for_table('tbl_customers')->whereRaw("coordinates != '' AND fullname LIKE ? OR username LIKE ? OR email LIKE ? OR phonenumber LIKE ?", [$like, $like, $like, $like])->order_by_desc('fullname');
             $c = Paginator::findMany($query, ['search' => $search], 50);
         }else{
             $query = ORM::for_table('tbl_customers')->where_not_equal('coordinates','');

--- a/system/controllers/paymentgateway.php
+++ b/system/controllers/paymentgateway.php
@@ -25,7 +25,8 @@ switch ($action) {
         $query->selects('id', 'username', 'gateway', 'gateway_trx_id', 'plan_id', 'plan_name', 'routers_id', 'routers', 'price', 'pg_url_payment', 'payment_method', 'payment_channel', 'expired_date', 'created_date', 'paid_date', 'trx_invoice', 'status');
         $query->where('gateway', $pg);
         if (!empty($q)) {
-            $query->whereRaw("(gateway_trx_id LIKE '%$q%' OR username LIKE '%$q%' OR routers LIKE '%$q%' OR plan_name LIKE '%$q%')");
+            $like = '%' . $q . '%';
+            $query->whereRaw("(gateway_trx_id LIKE ? OR username LIKE ? OR routers LIKE ? OR plan_name LIKE ?)", [$like, $like, $like, $like]);
             $append_url = 'q=' . urlencode($q);
         }
         $pgs = Paginator::findMany($query, ["search" => $search], 50, $append_url);


### PR DESCRIPTION
## What

Use **parameterized (bound) queries** for the free-text search filters in the
customer, payment-gateway, message, map, and live-autocomplete endpoints.

Previously these built the `WHERE` clause by interpolating the request value
directly into the SQL string passed to `whereRaw()` / `where_raw()`. This change
passes the value as a bound parameter instead, which is safer and more robust
(handles quotes/special characters correctly) with **no change in behaviour** —
same columns, same `LIKE` matching, same results.

## Why

- Hardens user-supplied search input against malformed/edge-case values.
- Follows the parameter-binding pattern Idiorm already supports
  (`where_raw($sql, $params)`), consistent with the rest of the query layer.

## Changes

| File | Endpoint |
|------|----------|
| `system/controllers/mail.php` | customer inbox search |
| `system/controllers/autoload.php` | customer autocomplete |
| `system/controllers/customers.php` | customer list search |
| `system/controllers/paymentgateway.php` | transaction search |
| `system/controllers/map.php` | customer map search |

Example:

```php
// before
$query->whereRaw("(subject like '%$q%' or body like '%$q%')");

// after
$like = '%' . $q . '%';
$query->whereRaw("(subject LIKE ? OR body LIKE ?)", [$like, $like]);
```

## Notes

- No schema changes, no behavioural changes, no new dependencies.
- Computed (non-user) raw expressions (e.g. a UNIX-timestamp comparison) are left as-is.
