### PR TITLE
Bug fix - The Pagination of ODP Lists not working properly 

### DIFF
--- a/system/controllers/odp.php
+++ b/system/controllers/odp.php
@@ -128,17 +128,17 @@ switch ($action) {
 
     default:
         run_hook('view_list_odp'); #HOOK
-		$name = _post('name');
+		$name = _req('name');
 		if ($name != ''){
-            $paginator = Paginator::build(ORM::for_table('tbl_odps'), ['name' => '%' . $name . '%'], $name);
-			$d = ORM::for_table('tbl_odps')->where_like('name','%'.$name.'%')->offset($paginator['startpoint'])->limit($paginator['limit'])->order_by_desc('id')->find_many();
+            $query = ORM::for_table('tbl_odps')->where_like('name','%'.$name.'%');
+            $d = Paginator::findMany($query, ['name' => $name], 10);
 		}else{
-            $paginator = Paginator::build(ORM::for_table('tbl_odps'));
-			$d = ORM::for_table('tbl_odps')->offset($paginator['startpoint'])->limit($paginator['limit'])->order_by_desc('id')->find_many();
-		}
+            $query = ORM::for_table('tbl_odps')->order_by_asc('id');
+            $d = Paginator::findMany($query);
+        }    
 
         $ui->assign('d',$d);
-		$ui->assign('paginator',$paginator);
+		$ui->assign('name',$name);
         $ui->display('admin/odp/list.tpl');
         break;
 }

--- a/ui/ui/admin/odp/list.tpl
+++ b/ui/ui/admin/odp/list.tpl
@@ -15,7 +15,7 @@
                                     <span class="fa fa-search"></span>
                                 </div>
                                 <input type="text" name="name" class="form-control"
-                                    placeholder="{Lang::T('Search by Name')}...">
+                                    placeholder="{Lang::T('Search by Name')}..." value="{$name}>
                                 <div class="input-group-btn">
                                     <button class="btn btn-success" type="submit">{Lang::T('Search')}</button>
                                 </div>


### PR DESCRIPTION
Pagination was not working properly when searching for a name. The paginator was not being assigned to the template when a search was performed. This has been fixed by ensuring that the paginator is always assigned, regardless of whether a search is performed or not.

Changes to be committed:
	modified:   system/controllers/odp.php
	modified:   ui/ui/admin/odp/list.tpl
	
**Preview**

Before:

<img width="1639" height="725" alt="odp-list-before" src="https://github.com/user-attachments/assets/6ae3a5c8-5d9b-435d-b4e1-9e7c3ae044e3" />

After:

<img width="1639" height="725" alt="odp-list-after" src="https://github.com/user-attachments/assets/439e44cb-4888-4304-9ba8-a63eeb6958ba" />
